### PR TITLE
fix: Fix `day` enum `in `dependabot`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "Sunday"
+      day: "sunday"
       time: "09:00"
       timezone: "Europe/London"
     commit-message:
@@ -23,7 +23,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "Sunday"
+      day: "sunday"
       time: "09:00"
       timezone: "Europe/London"
     commit-message:


### PR DESCRIPTION
A capital 'S' in 'Sunday' is not valid, apparently.