### PR TITLE
feat: Add image magnification lightbox for team and hero images

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -270,3 +270,131 @@ button:focus {
     transform: translateY(-2px);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
+
+/* Image Lightbox Styles */
+.lightbox {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.lightbox.active {
+    opacity: 1;
+    visibility: visible;
+}
+
+.lightbox.hidden {
+    display: none;
+}
+
+.lightbox-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.9);
+    cursor: pointer;
+}
+
+.lightbox-content {
+    position: relative;
+    max-width: 90%;
+    max-height: 90%;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.lightbox-image {
+    max-width: 100%;
+    max-height: 90vh;
+    object-fit: contain;
+    border-radius: 8px;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+.lightbox-close {
+    position: absolute;
+    top: -50px;
+    right: 0;
+    background-color: rgba(255, 255, 255, 0.9);
+    border: none;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    color: var(--content-text);
+    font-size: 20px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10001;
+}
+
+.lightbox-close:hover {
+    background-color: white;
+    transform: rotate(90deg);
+}
+
+.lightbox-close:focus {
+    outline: 2px solid white;
+    outline-offset: 2px;
+}
+
+/* Clickable images cursor */
+.clickable-image {
+    cursor: pointer;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.clickable-image:hover {
+    transform: scale(1.05);
+    opacity: 0.9;
+}
+
+.clickable-image:focus {
+    outline: 2px solid var(--header-icon);
+    outline-offset: 2px;
+}
+
+/* Hero image magnify icon */
+.hero-magnify-icon {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    background-color: rgba(255, 255, 255, 0.9);
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    z-index: 10;
+    color: var(--content-text);
+    font-size: 18px;
+}
+
+.hero-magnify-icon:hover {
+    background-color: white;
+    transform: scale(1.1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.hero-magnify-icon:focus {
+    outline: 2px solid white;
+    outline-offset: 2px;
+}

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -210,6 +210,107 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    // Image Lightbox Functionality
+    const lightbox = document.getElementById('image-lightbox');
+    const lightboxImage = lightbox.querySelector('.lightbox-image');
+    const lightboxClose = lightbox.querySelector('.lightbox-close');
+    const lightboxBackdrop = lightbox.querySelector('.lightbox-backdrop');
+
+    // Function to open lightbox
+    function openLightbox(imageSrc, imageAlt) {
+        lightboxImage.src = imageSrc;
+        lightboxImage.alt = imageAlt;
+        lightbox.classList.remove('hidden');
+        // Use setTimeout to ensure the display change happens before opacity change
+        setTimeout(() => {
+            lightbox.classList.add('active');
+        }, 10);
+        document.body.style.overflow = 'hidden';
+    }
+
+    // Function to close lightbox
+    function closeLightbox() {
+        lightbox.classList.remove('active');
+        setTimeout(() => {
+            lightbox.classList.add('hidden');
+            lightboxImage.src = '';
+            lightboxImage.alt = '';
+            document.body.style.overflow = '';
+        }, 300);
+    }
+
+    // Add click listeners to team photos (clickable-image class)
+    document.querySelectorAll('.clickable-image').forEach(img => {
+        // Make images keyboard accessible
+        img.setAttribute('tabindex', '0');
+        img.setAttribute('role', 'button');
+
+        // Click handler
+        img.addEventListener('click', function() {
+            const src = this.src;
+            const alt = this.alt;
+            openLightbox(src, alt);
+        });
+
+        // Keyboard handler (Enter and Space keys)
+        img.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                const src = this.src;
+                const alt = this.alt;
+                openLightbox(src, alt);
+            }
+        });
+    });
+
+    // Add click listeners to hero images (background images on hero-slide)
+    document.querySelectorAll('.hero-slide').forEach(slide => {
+        // Extract background image URL from inline style
+        const style = slide.getAttribute('style') || '';
+        const urlMatch = style.match(/url\(['"]?([^'")\s]+)['"]?\)/);
+
+        if (urlMatch && urlMatch[1]) {
+            const imageUrl = urlMatch[1];
+
+            // Add magnify icon overlay
+            const magnifyIcon = document.createElement('div');
+            magnifyIcon.className = 'hero-magnify-icon';
+            magnifyIcon.innerHTML = '<i class="fas fa-search-plus"></i>';
+            magnifyIcon.setAttribute('tabindex', '0');
+            magnifyIcon.setAttribute('role', 'button');
+            magnifyIcon.setAttribute('aria-label', 'View image full size');
+            slide.style.position = 'relative';
+            slide.appendChild(magnifyIcon);
+
+            // Click handler for magnify icon
+            magnifyIcon.addEventListener('click', function(e) {
+                e.stopPropagation();
+                openLightbox(imageUrl, 'Hero image');
+            });
+
+            // Keyboard handler for magnify icon
+            magnifyIcon.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    openLightbox(imageUrl, 'Hero image');
+                }
+            });
+        }
+    });
+
+    // Close lightbox on close button click
+    lightboxClose.addEventListener('click', closeLightbox);
+
+    // Close lightbox on backdrop click
+    lightboxBackdrop.addEventListener('click', closeLightbox);
+
+    // Close lightbox on Escape key
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape' && lightbox.classList.contains('active')) {
+            closeLightbox();
+        }
+    });
+
     // Console welcome message
     console.log('%c🔧 Welcome to Basingstoke Repair Network! 🔧', 'color: #28276f; font-size: 16px; font-weight: bold;');
     console.log('%cInterested in contributing? Contact us at info@chinehamrepair.org.uk', 'color: #02011A; font-size: 12px;');

--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,7 @@ SPDX-License-Identifier: MIT
             <div id="chineham" class="max-w-4xl mx-auto mb-12 bg-white rounded-lg shadow-lg overflow-hidden">
                 <div class="md:flex">
                     <div class="md:w-1/3">
-                        <img src="assets/images/locations/chineham-team.jpg" alt="Chineham Repair Café Team" class="w-full h-64 md:h-full object-cover" onerror="this.src='https://picsum.photos/400/300?';">
+                        <img src="assets/images/locations/chineham-team.jpg" alt="Chineham Repair Café Team" class="w-full h-64 md:h-full object-cover clickable-image" onerror="this.src='https://picsum.photos/400/300?';">
                     </div>
                     <div class="p-8 md:w-2/3">
                         <h3 class="text-3xl font-bold mb-4 text-blue-600">Chineham Repair Café</h3>
@@ -186,7 +186,7 @@ SPDX-License-Identifier: MIT
             <div id="hatch-warren" class="max-w-4xl mx-auto mb-12 bg-white rounded-lg shadow-lg overflow-hidden">
                 <div class="md:flex md:flex-row-reverse">
                     <div class="md:w-1/3">
-                        <img src="assets/images/locations/hatch-warren-team.jpg" alt="Hatch Warren Repair Café Team" class="w-full h-64 md:h-full object-cover" onerror="this.src='https://picsum.photos/400/300';">
+                        <img src="assets/images/locations/hatch-warren-team.jpg" alt="Hatch Warren Repair Café Team" class="w-full h-64 md:h-full object-cover clickable-image" onerror="this.src='https://picsum.photos/400/300';">
                     </div>
                     <div class="p-8 md:w-2/3">
                         <h3 class="text-3xl font-bold mb-4 text-green-600">Hatch Warren & Beggarwood Repair Café</h3>
@@ -367,6 +367,17 @@ SPDX-License-Identifier: MIT
             </div>
         </div>
     </footer>
+
+    <!-- Image Lightbox Modal -->
+    <div id="image-lightbox" class="lightbox hidden" role="dialog" aria-modal="true" aria-label="Image viewer">
+        <div class="lightbox-backdrop"></div>
+        <div class="lightbox-content">
+            <button class="lightbox-close" aria-label="Close image viewer">
+                <i class="fas fa-times"></i>
+            </button>
+            <img class="lightbox-image" src="" alt="">
+        </div>
+    </div>
 
     <!-- Swiper JS for carousel -->
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>


### PR DESCRIPTION
Implemented a clickable image lightbox feature that allows users to view team photos and hero carousel images in full size.

Features:
- Click team photos to view enlarged
- Click magnify icon on hero carousel to view full image
- Smooth fade-in/fade-out animations
- Close via X button, backdrop click, or Escape key
- Keyboard accessible (Enter/Space to open, Escape to close)
- Responsive design with max 90vh height for large images
- Prevents body scroll when lightbox is open
- ARIA labels for screen readers

Technical implementation:
- Added lightbox modal HTML structure with backdrop and close button
- CSS styles with fixed positioning and z-index layering
- JavaScript event handlers for click, keyboard, and close actions
- Applied 'clickable-image' class to team photos
- Added magnify icon overlay to hero slides
- Hover effects show cursor pointer and slight scale animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>