### PR TITLE
feat: Add name labels and accessibility tooltips to supporter logos

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -109,10 +109,19 @@ body {
 /* Supporter Logos */
 .supporter-logo {
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     padding: 1rem;
     transition: transform 0.3s ease;
+}
+
+.supporter-logo .supporter-name {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--content-text);
+    text-align: center;
 }
 
 .supporter-logo:hover {

--- a/public/index.html
+++ b/public/index.html
@@ -312,30 +312,38 @@ SPDX-License-Identifier: MIT
                     </p>
                     <div class="grid grid-cols-2 md:grid-cols-4 gap-8 items-center">
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/basingstoke-council.png" alt="Basingstoke & Deane Council" class="clickable-image" onerror="this.parentElement.innerHTML='<div class=\'text-center text-sm font-semibold\'>B&D Council</div>';">
+                            <img src="assets/images/supporters/basingstoke-council.png" alt="Basingstoke & Deane Council" title="Basingstoke & Deane Council - Supporting local community initiatives" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <span class="supporter-name">Basingstoke & Deane Council</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/four-lanes-trust.png" alt="Four Lanes Trust" class="clickable-image" onerror="this.parentElement.innerHTML='<div class=\'text-center text-sm font-semibold\'>Four Lanes Trust</div>';">
+                            <img src="assets/images/supporters/four-lanes-trust.png" alt="Four Lanes Trust" title="Four Lanes Trust - Community funding and support" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <span class="supporter-name">Four Lanes Trust</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/restarters.png" alt="Restarters.net" class="clickable-image" onerror="this.parentElement.innerHTML='<div class=\'text-center text-sm font-semibold\'>Restarters.net</div>';">
+                            <img src="assets/images/supporters/restarters.png" alt="Restarters.net" title="Restarters.net - Community repair data and resources" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <span class="supporter-name">Restarters.net</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/repair-cafe-international.png" alt="Repair Café International" class="clickable-image" onerror="this.parentElement.innerHTML='<div class=\'text-center text-sm font-semibold\'>Repair Café Int\'l</div>';">
+                            <img src="assets/images/supporters/repair-cafe-international.png" alt="Repair Café International" title="Repair Café International - Global repair café network" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <span class="supporter-name">Repair Café International</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/greener-basingstoke.png" alt="Greener Basingstoke" class="clickable-image" onerror="this.parentElement.innerHTML='<div class=\'text-center text-sm font-semibold\'>Greener Basingstoke</div>';">
+                            <img src="assets/images/supporters/greener-basingstoke.png" alt="Greener Basingstoke" title="Greener Basingstoke - Local environmental initiatives" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <span class="supporter-name">Greener Basingstoke</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/national-lottery.png" alt="National Lottery" class="clickable-image" onerror="this.parentElement.innerHTML='<div class=\'text-center text-sm font-semibold\'>National Lottery</div>';">
+                            <img src="assets/images/supporters/national-lottery.png" alt="National Lottery Community Fund" title="National Lottery Community Fund - Funding good causes" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <span class="supporter-name">National Lottery</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/veolia.png" alt="Veolia" class="clickable-image" onerror="this.parentElement.innerHTML='<div class=\'text-center text-sm font-semibold\'>Veolia</div>';">
+                            <img src="assets/images/supporters/veolia.png" alt="Veolia" title="Veolia - Environmental services and sustainability" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <span class="supporter-name">Veolia</span>
                         </div>
                         <div class="supporter-logo">
                             <a href="https://www.oakleystitchers.org.uk/" target="_blank" rel="noopener noreferrer">
-                                <img src="assets/images/supporters/oakley-stitchers.jpg" alt="Oakley Stitchers CIC" onerror="this.parentElement.innerHTML='<div class=\'text-center text-sm font-semibold\'>Oakley Stitchers CIC</div>';">
+                                <img src="assets/images/supporters/oakley-stitchers.jpg" alt="Oakley Stitchers CIC" title="Oakley Stitchers CIC - Community sewing and textile repairs" class="clickable-image" onerror="this.style.display='none'; this.parentElement.nextElementSibling.classList.add('text-sm', 'font-semibold');">
                             </a>
+                            <span class="supporter-name">Oakley Stitchers CIC</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- Add visible name labels beneath each supporter logo
- Add title attributes with descriptive tooltips for accessibility
- Update CSS to support vertical layout with flex-direction column
- Improve onerror handlers to gracefully hide broken images while preserving labels