### PR TITLE
feat: Add clickable links to supporter logos

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -312,35 +312,49 @@ SPDX-License-Identifier: MIT
                     </p>
                     <div class="grid grid-cols-2 md:grid-cols-4 gap-8 items-center">
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/basingstoke-council.png" alt="Basingstoke & Deane Council" title="Basingstoke & Deane Council - Supporting local community initiatives" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <a href="https://www.basingstoke.gov.uk/" target="_blank" rel="noopener noreferrer" aria-label="Visit Basingstoke & Deane Council website">
+                                <img src="assets/images/supporters/basingstoke-council.png" alt="Basingstoke & Deane Council" title="Basingstoke & Deane Council - Supporting local community initiatives" class="clickable-image" onerror="this.style.display='none'; this.parentElement.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            </a>
                             <span class="supporter-name">Basingstoke & Deane Council</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/four-lanes-trust.png" alt="Four Lanes Trust" title="Four Lanes Trust - Community funding and support" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <a href="https://example.com/four-lanes-trust" target="_blank" rel="noopener noreferrer" aria-label="Visit Four Lanes Trust website">
+                                <img src="assets/images/supporters/four-lanes-trust.png" alt="Four Lanes Trust" title="Four Lanes Trust - Community funding and support" class="clickable-image" onerror="this.style.display='none'; this.parentElement.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            </a>
                             <span class="supporter-name">Four Lanes Trust</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/restarters.png" alt="Restarters.net" title="Restarters.net - Community repair data and resources" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <a href="https://restarters.net/" target="_blank" rel="noopener noreferrer" aria-label="Visit Restarters.net website">
+                                <img src="assets/images/supporters/restarters.png" alt="Restarters.net" title="Restarters.net - Community repair data and resources" class="clickable-image" onerror="this.style.display='none'; this.parentElement.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            </a>
                             <span class="supporter-name">Restarters.net</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/repair-cafe-international.png" alt="Repair Café International" title="Repair Café International - Global repair café network" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <a href="https://www.repaircafe.org/" target="_blank" rel="noopener noreferrer" aria-label="Visit Repair Café International website">
+                                <img src="assets/images/supporters/repair-cafe-international.png" alt="Repair Café International" title="Repair Café International - Global repair café network" class="clickable-image" onerror="this.style.display='none'; this.parentElement.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            </a>
                             <span class="supporter-name">Repair Café International</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/greener-basingstoke.png" alt="Greener Basingstoke" title="Greener Basingstoke - Local environmental initiatives" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <a href="https://example.com/greener-basingstoke" target="_blank" rel="noopener noreferrer" aria-label="Visit Greener Basingstoke website">
+                                <img src="assets/images/supporters/greener-basingstoke.png" alt="Greener Basingstoke" title="Greener Basingstoke - Local environmental initiatives" class="clickable-image" onerror="this.style.display='none'; this.parentElement.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            </a>
                             <span class="supporter-name">Greener Basingstoke</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/national-lottery.png" alt="National Lottery Community Fund" title="National Lottery Community Fund - Funding good causes" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <a href="https://example.com/national-lottery" target="_blank" rel="noopener noreferrer" aria-label="Visit National Lottery website">
+                                <img src="assets/images/supporters/national-lottery.png" alt="National Lottery Community Fund" title="National Lottery Community Fund - Funding good causes" class="clickable-image" onerror="this.style.display='none'; this.parentElement.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            </a>
                             <span class="supporter-name">National Lottery</span>
                         </div>
                         <div class="supporter-logo">
-                            <img src="assets/images/supporters/veolia.png" alt="Veolia" title="Veolia - Environmental services and sustainability" class="clickable-image" onerror="this.style.display='none'; this.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            <a href="https://example.com/veolia" target="_blank" rel="noopener noreferrer" aria-label="Visit Veolia website">
+                                <img src="assets/images/supporters/veolia.png" alt="Veolia" title="Veolia - Environmental services and sustainability" class="clickable-image" onerror="this.style.display='none'; this.parentElement.nextElementSibling.classList.add('text-sm', 'font-semibold');">
+                            </a>
                             <span class="supporter-name">Veolia</span>
                         </div>
                         <div class="supporter-logo">
-                            <a href="https://www.oakleystitchers.org.uk/" target="_blank" rel="noopener noreferrer">
+                            <a href="https://www.oakleystitchers.org.uk/" target="_blank" rel="noopener noreferrer" aria-label="Visit Oakley Stitchers CIC website">
                                 <img src="assets/images/supporters/oakley-stitchers.jpg" alt="Oakley Stitchers CIC" title="Oakley Stitchers CIC - Community sewing and textile repairs" class="clickable-image" onerror="this.style.display='none'; this.parentElement.nextElementSibling.classList.add('text-sm', 'font-semibold');">
                             </a>
                             <span class="supporter-name">Oakley Stitchers CIC</span>


### PR DESCRIPTION
Wrapped all 7 supporter organization logos in anchor tags to make them clickable and navigable to their respective websites.

Changes:
- Added links to all supporter logos in the supporters section
- Each link opens in a new tab with proper security attributes (target="_blank" rel="noopener noreferrer")
- Added descriptive ARIA labels for accessibility
- Used actual URLs where known (Basingstoke Council, Restarters.net, Repair Café International)
- Used placeholder URLs for organizations requiring URL confirmation (Four Lanes Trust, Greener Basingstoke, National Lottery, Veolia)

Technical details:
- All external links follow security best practices
- Maintains semantic HTML structure
- Preserves existing image error handling
- Keyboard accessible through standard link navigation

Note: Placeholder URLs (https://example.com/*) should be replaced with actual organization websites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)