### PR TITLE
Fix BRN logo fluid responsive scaling

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -37,6 +37,18 @@ body {
     text-decoration: none;
 }
 
+/* BRN Logo - Fluid responsive scaling */
+.brn-logo {
+    display: block;
+    height: 4rem; /* Fallback for browsers without clamp() */
+    height: clamp(3rem, 8vw, 5rem);
+    width: auto;
+    min-width: 0; /* Allow shrinking in flex container */
+    flex-shrink: 0; /* Prevent flex squashing */
+    object-fit: contain;
+    aspect-ratio: auto; /* Maintain intrinsic aspect ratio */
+}
+
 /* Content Styles */
 .content-bg {
     background-color: var(--content-bg);

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@ SPDX-License-Identifier: MIT
             <div class="flex justify-between items-center">
                 <!-- Logo -->
                 <div class="flex items-center">
-                    <img src="assets/images/logos/brn-logo.png" alt="Basingstoke Repair Network Logo" class="h-12 md:h-16" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                    <img src="assets/images/logos/brn-logo.png" alt="Basingstoke Repair Network Logo" class="brn-logo" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
                     <div class="text-2xl font-bold header-icon-color hidden">BRN</div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Replace fixed Tailwind breakpoint classes with modern CSS `clamp()` for fluid logo scaling
- Logo now scales smoothly as a percentage of viewport width (48px–80px) while preserving aspect ratio
- Adds cross-browser fallbacks for older browsers without `clamp()` support