### PR TITLE
feat: add Swiper.js hero carousel

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -41,29 +41,51 @@ const slides = allSlides
 
 <script>
   document.addEventListener('DOMContentLoaded', () => {
-    if (typeof window.Swiper !== 'undefined') {
-      new window.Swiper('.hero-swiper', {
-        loop: true,
-        autoplay: {
-          delay: 5000,
-          disableOnInteraction: false,
-          pauseOnMouseEnter: true,
-        },
-        effect: 'fade',
-        fadeEffect: { crossFade: true },
-        pagination: {
-          el: '.swiper-pagination',
-          clickable: true,
-        },
-        navigation: {
-          nextEl: '.swiper-button-next',
-          prevEl: '.swiper-button-prev',
-        },
-        a11y: {
-          prevSlideMessage: 'Previous slide',
-          nextSlideMessage: 'Next slide',
-        },
-      });
-    }
+    if (typeof window.Swiper === 'undefined') return;
+
+    new window.Swiper('.hero-swiper', {
+      loop: true,
+      autoplay: {
+        delay: 5000,
+        disableOnInteraction: false,
+        pauseOnMouseEnter: true,
+      },
+      effect: 'fade',
+      fadeEffect: { crossFade: true },
+      keyboard: {
+        enabled: true,
+        onlyInViewport: true,
+      },
+      pagination: {
+        el: '.swiper-pagination',
+        clickable: true,
+      },
+      navigation: {
+        nextEl: '.swiper-button-next',
+        prevEl: '.swiper-button-prev',
+      },
+      a11y: {
+        prevSlideMessage: 'Previous slide',
+        nextSlideMessage: 'Next slide',
+        enabled: true,
+      },
+    });
+
+    // On touch devices, briefly reveal arrows so users know they exist,
+    // then hide them again after 2.5 s of inactivity.
+    const swiperEl = document.querySelector('.hero-swiper');
+    if (!swiperEl) return;
+
+    let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const showArrows = () => {
+      swiperEl.classList.add('arrows-visible');
+      if (hideTimer) clearTimeout(hideTimer);
+      hideTimer = setTimeout(() => {
+        swiperEl.classList.remove('arrows-visible');
+      }, 2500);
+    };
+
+    swiperEl.addEventListener('touchstart', showArrows, { passive: true });
   });
 </script>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -3,18 +3,67 @@ SPDX-FileCopyrightText: 2025 Basingstoke Repair Network
 SPDX-License-Identifier: MIT
 -->
 ---
+import { getCollection } from 'astro:content';
+
+const allSlides = await getCollection('hero-slides');
+const slides = allSlides
+  .filter((s) => s.data.isActive !== false)
+  .sort((a, b) => a.data.order - b.data.order);
 ---
 
-<section class="hero-section" aria-label="Welcome to Basingstoke Repair Network">
-  <div class="brn-container">
-    <h1>Fix It, Don't Bin It!</h1>
-    <p class="hero-tagline">
-      Our Repair Cafés are here to help fix your broken things, saving you
-      money, and keeping them out of landfill.
-    </p>
-    <div class="hero-cta">
-      <a href="#locations" class="btn btn-primary">Find a Repair Café</a>
-      <a href="#volunteer" class="btn btn-secondary">Volunteer With Us</a>
+<section class="hero-carousel-section" aria-label="Welcome to Basingstoke Repair Network">
+  <div class="swiper hero-swiper">
+    <div class="swiper-wrapper">
+      {slides.map(({ data }) => (
+        <div
+          class="swiper-slide hero-slide"
+          style={`background-image: url('${data.backgroundImage}')`}
+        >
+          <div class="hero-slide-overlay" aria-hidden="true"></div>
+          <div class="brn-container hero-slide-content">
+            <h1>{data.title}</h1>
+            <p class="hero-tagline">{data.subtitle}</p>
+            {data.ctaText && data.ctaLink && (
+              <div class="hero-cta">
+                <a href={data.ctaLink} class="btn btn-primary">{data.ctaText}</a>
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
     </div>
+
+    <div class="swiper-pagination"></div>
+    <div class="swiper-button-prev" aria-label="Previous slide"></div>
+    <div class="swiper-button-next" aria-label="Next slide"></div>
   </div>
 </section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    if (typeof window.Swiper !== 'undefined') {
+      new window.Swiper('.hero-swiper', {
+        loop: true,
+        autoplay: {
+          delay: 5000,
+          disableOnInteraction: false,
+          pauseOnMouseEnter: true,
+        },
+        effect: 'fade',
+        fadeEffect: { crossFade: true },
+        pagination: {
+          el: '.swiper-pagination',
+          clickable: true,
+        },
+        navigation: {
+          nextEl: '.swiper-button-next',
+          prevEl: '.swiper-button-prev',
+        },
+        a11y: {
+          prevSlideMessage: 'Previous slide',
+          nextSlideMessage: 'Next slide',
+        },
+      });
+    }
+  });
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,6 +39,16 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://basingst
 
     <!-- Preconnect for maps (lazy loaded) -->
     <link rel="preconnect" href="https://maps.google.com" />
+
+    <!-- Swiper.js carousel (CDN) -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css"
+    />
+    <script
+      src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"
+      defer
+    ></script>
   </head>
   <body>
     <slot />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -244,59 +244,65 @@ img {
 }
 
 /* =========================================================
-   Hero section
+   Hero carousel
    ========================================================= */
 
-.hero-section {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-dark) 0%,
-    var(--color-primary) 100%
-  );
-  color: var(--color-white);
-  padding: var(--space-3xl) var(--space-md);
-  text-align: center;
+.hero-carousel-section {
   position: relative;
   overflow: hidden;
 }
 
-.hero-section::before {
-  content: "🔧 ✂️ 🔌";
-  position: absolute;
-  top: 10%;
-  right: 5%;
-  font-size: clamp(2rem, 6vw, 4rem);
-  opacity: 0.15;
-  pointer-events: none;
-  user-select: none;
+.hero-swiper {
+  width: 100%;
+  height: clamp(420px, 60vh, 700px);
 }
 
-.hero-section::after {
-  content: "🧵 🪑 🚲";
-  position: absolute;
-  bottom: 10%;
-  left: 5%;
-  font-size: clamp(2rem, 6vw, 4rem);
-  opacity: 0.15;
-  pointer-events: none;
-  user-select: none;
+.hero-slide {
+  background-size: cover;
+  background-position: center;
+  background-color: var(--color-primary-dark);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
 }
 
-.hero-section h1 {
+.hero-slide-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(26, 24, 80, 0.72) 0%,
+    rgba(40, 39, 111, 0.55) 100%
+  );
+}
+
+.hero-slide-content {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  color: var(--color-white);
+  padding-top: var(--space-2xl);
+  padding-bottom: var(--space-2xl);
+}
+
+.hero-slide-content h1 {
   color: var(--color-white);
   margin-bottom: var(--space-lg);
+  text-shadow: 0 2px 8px rgba(2, 1, 26, 0.4);
 }
 
-.hero-section h1::after {
+.hero-slide-content h1::after {
   display: none;
 }
 
 .hero-tagline {
-  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-size: clamp(1.1rem, 2.5vw, 1.5rem);
   max-width: 700px;
   margin: 0 auto var(--space-lg);
   font-weight: 300;
   color: var(--color-white);
+  text-shadow: 0 1px 4px rgba(2, 1, 26, 0.5);
 }
 
 .hero-cta {
@@ -304,6 +310,28 @@ img {
   gap: var(--space-md);
   flex-wrap: wrap;
   justify-content: center;
+}
+
+/* Swiper colour overrides — BRN brand blue */
+.hero-swiper .swiper-pagination-bullet {
+  background: var(--color-white);
+  opacity: 0.6;
+}
+
+.hero-swiper .swiper-pagination-bullet-active {
+  background: var(--color-white);
+  opacity: 1;
+}
+
+.hero-swiper .swiper-button-prev,
+.hero-swiper .swiper-button-next {
+  color: var(--color-white);
+  text-shadow: 0 1px 4px rgba(2, 1, 26, 0.5);
+}
+
+.hero-swiper .swiper-button-prev:hover,
+.hero-swiper .swiper-button-next:hover {
+  color: var(--color-gray);
 }
 
 /* Buttons */
@@ -703,11 +731,6 @@ button:focus-visible {
     text-align: center;
   }
 
-  .hero-section::before,
-  .hero-section::after {
-    display: none;
-  }
-
   .map-container {
     height: 250px;
   }
@@ -769,10 +792,6 @@ button:focus-visible {
     grid-template-columns: repeat(3, 1fr);
   }
 
-  .hero-section {
-    padding: var(--space-3xl) var(--space-xl);
-  }
-
   .supporters-grid {
     grid-template-columns: repeat(4, 1fr);
   }
@@ -831,13 +850,8 @@ button:focus-visible {
     box-shadow: none;
   }
 
-  .hero-section {
-    background: white;
-    color: black;
-  }
-
-  .hero-section h1 {
-    color: black;
+  .hero-carousel-section {
+    display: none;
   }
 
   .btn {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -323,15 +323,51 @@ img {
   opacity: 1;
 }
 
+/* Arrows: hidden by default, revealed on hover / keyboard focus / touch */
 .hero-swiper .swiper-button-prev,
 .hero-swiper .swiper-button-next {
   color: var(--color-white);
   text-shadow: 0 1px 4px rgba(2, 1, 26, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, color 0.2s ease;
+}
+
+/* Desktop hover */
+.hero-swiper:hover .swiper-button-prev,
+.hero-swiper:hover .swiper-button-next {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Keyboard focus — covers Tab → button and arrow-key navigation */
+.hero-swiper:focus-within .swiper-button-prev,
+.hero-swiper:focus-within .swiper-button-next {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Touch-triggered reveal (class added by JS on touchstart) */
+.hero-swiper.arrows-visible .swiper-button-prev,
+.hero-swiper.arrows-visible .swiper-button-next {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .hero-swiper .swiper-button-prev:hover,
-.hero-swiper .swiper-button-next:hover {
+.hero-swiper .swiper-button-next:hover,
+.hero-swiper .swiper-button-prev:focus-visible,
+.hero-swiper .swiper-button-next:focus-visible {
   color: var(--color-gray);
+  outline: none;
+}
+
+/* On mobile, remove arrows entirely — swipe + dots is the right gesture */
+@media (max-width: 639px) {
+  .hero-swiper .swiper-button-prev,
+  .hero-swiper .swiper-button-next {
+    display: none;
+  }
 }
 
 /* Buttons */


### PR DESCRIPTION
feat: add Swiper.js hero carousel

Add Swiper.js v11 via CDN, introduce hero-slides content collection,
replace static hero with a full-width carousel, and add carousel CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

_and_

feat: refine carousel UX

Hide navigation arrows by default; reveal on desktop hover, keyboard
focus, and touch interaction. Add full keyboard navigation support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
