### PR TITLE
fix(ci): Append PR's ref on top of concurrency group ID

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: 'pages'
+  group: 'pages-${{ github.ref }}'
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
This allows multiple CI jobs to run across different PRs, which will have different refs.