### PR TITLE
fix(ci): Disable commit comment/statuses upon deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"
           enable-pull-request-comment: true
-          enable-commit-comment: true
-          enable-commit-status: true
+          enable-commit-comment: false
+          enable-commit-status: false
           enable-github-deployment: true
           overwrites-pull-request-comment: true
         env:


### PR DESCRIPTION
This commit instructs CI to not comment or update statuses of each commit, reducing noise in GitHub notifications.