### PR TITLE
fix: reduce spacing between page sections

### DIFF
--- a/src/components/Supporters.astro
+++ b/src/components/Supporters.astro
@@ -11,7 +11,7 @@ const supporters = allSupporters
   .sort((a, b) => a.data.order - b.data.order);
 ---
 
-<section id="supporters" class="page-section section-alt">
+<section id="supporters" class="page-section section-alt section-compact">
   <div class="brn-container">
     <h2>Our supporters</h2>
     <p class="section-intro">

--- a/src/components/Volunteer.astro
+++ b/src/components/Volunteer.astro
@@ -20,7 +20,7 @@ const skills = [
 ];
 ---
 
-<section id="volunteer" class="page-section section-alt">
+<section id="volunteer" class="page-section section-alt section-compact">
   <div class="brn-container">
     <h2>We need you!</h2>
     <p class="section-intro">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -435,8 +435,8 @@ img {
 }
 
 .section-compact {
-  padding-top: var(--space-xl);
-  padding-bottom: var(--space-xl);
+  padding-top: var(--space-lg);
+  padding-bottom: var(--space-lg);
 }
 
 .bg-white {
@@ -884,7 +884,8 @@ button:focus-visible {
   }
 
   .page-section {
-    padding: var(--space-3xl) var(--space-xl);
+    padding-left: var(--space-xl);
+    padding-right: var(--space-xl);
   }
 
   .card-grid {


### PR DESCRIPTION
Per Rory's feedback on #106, the gap between sections was too large. Cut .section-compact's vertical padding from 2rem to 1.5rem and apply it to the Volunteer and Supporters sections (they were still using the full 4rem padding, uneven versus other sections). Also stop the desktop (>=1024px) breakpoint's .page-section rule from clobbering .section-compact's reduced vertical padding with its shorthand `padding` declaration — it now only sets left/right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)