### PR TITLE
feat: alternate section background colour

### DIFF
--- a/src/components/HowItWorks.astro
+++ b/src/components/HowItWorks.astro
@@ -53,7 +53,7 @@ const photos = [
 ];
 ---
 
-<section id="about" class="page-section section-alt section-compact">
+<section id="about" class="page-section section-compact">
   <div class="brn-container">
     <h2>How it works</h2>
     <p class="section-intro">

--- a/src/components/Supporters.astro
+++ b/src/components/Supporters.astro
@@ -11,7 +11,7 @@ const supporters = allSupporters
   .sort((a, b) => a.data.order - b.data.order);
 ---
 
-<section id="supporters" class="page-section section-alt">
+<section id="supporters" class="page-section">
   <div class="brn-container">
     <h2>Our supporters</h2>
     <p class="section-intro">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -462,7 +462,7 @@ img {
 }
 
 .card {
-  background: var(--color-bg);
+  background: var(--color-white);
   border-radius: var(--radius-lg);
   padding: var(--space-lg);
   border-left: 4px solid var(--color-primary-dark);


### PR DESCRIPTION
Per Rory's feedback on #106, alternate the page-background colour (#eeeeee) and white down the page instead of clustering several white sections together: How it works and Our supporters drop `section-alt` so they fall back to the default grey background, alternating with the white Why repair and We need you sections and the grey Locations section.

Also fix `.card` (used by How it works / Why repair) to use a white background instead of grey — it previously matched the page background exactly, so cards would have become invisible on the newly-grey How it works section. `.section-alt .card` still overrides to grey, keeping contrast on the white sections too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)