### PR TITLE
fix: alternate section backgrounds and tighten spacing per #106

### DIFF
--- a/src/components/HowItWorks.astro
+++ b/src/components/HowItWorks.astro
@@ -53,7 +53,7 @@ const photos = [
 ];
 ---
 
-<section id="about" class="page-section section-alt section-compact">
+<section id="about" class="page-section section-compact">
   <div class="brn-container">
     <h2>How it works</h2>
     <p class="section-intro">

--- a/src/components/Supporters.astro
+++ b/src/components/Supporters.astro
@@ -11,7 +11,7 @@ const supporters = allSupporters
   .sort((a, b) => a.data.order - b.data.order);
 ---
 
-<section id="supporters" class="page-section section-alt">
+<section id="supporters" class="page-section section-alt section-compact">
   <div class="brn-container">
     <h2>Our supporters</h2>
     <p class="section-intro">

--- a/src/components/Supporters.astro
+++ b/src/components/Supporters.astro
@@ -11,7 +11,7 @@ const supporters = allSupporters
   .sort((a, b) => a.data.order - b.data.order);
 ---
 
-<section id="supporters" class="page-section section-alt section-compact">
+<section id="supporters" class="page-section section-compact">
   <div class="brn-container">
     <h2>Our supporters</h2>
     <p class="section-intro">

--- a/src/components/Volunteer.astro
+++ b/src/components/Volunteer.astro
@@ -20,7 +20,7 @@ const skills = [
 ];
 ---
 
-<section id="volunteer" class="page-section section-alt">
+<section id="volunteer" class="page-section section-alt section-compact">
   <div class="brn-container">
     <h2>We need you!</h2>
     <p class="section-intro">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -435,8 +435,8 @@ img {
 }
 
 .section-compact {
-  padding-top: var(--space-xl);
-  padding-bottom: var(--space-xl);
+  padding-top: var(--space-lg);
+  padding-bottom: var(--space-lg);
 }
 
 .bg-white {
@@ -884,7 +884,8 @@ button:focus-visible {
   }
 
   .page-section {
-    padding: var(--space-3xl) var(--space-xl);
+    padding-left: var(--space-xl);
+    padding-right: var(--space-xl);
   }
 
   .card-grid {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -462,7 +462,7 @@ img {
 }
 
 .card {
-  background: var(--color-bg);
+  background: var(--color-white);
   border-radius: var(--radius-lg);
   padding: var(--space-lg);
   border-left: 4px solid var(--color-primary-dark);


### PR DESCRIPTION
## Summary
Implements Rory's feedback on #106 (comment [#issuecomment-5016397901](https://github.com/basingstoke-repair-network/apex-site-basingstoke.repair/issues/106#issuecomment-5016397901)), landed as two isolated commits:

- **Alternate section background colour** — sections now alternate between white and the grey `#eeeeee` background instead of clustering several white sections together (How it works and Our supporters drop `section-alt` to fall back to grey; Why repair, We need you, and Locations keep the existing pattern). Also fixes `.card` (used by How it works / Why repair) which previously matched the page background exactly — it's now white by default so it doesn't disappear on a grey section, with `.section-alt .card` still overriding to grey for contrast on white sections.
- **Reduce spacing between sections** — cuts `.section-compact`'s vertical padding from `2rem` to `1.5rem` and applies it consistently to the Volunteer and Supporters sections (they were still using the full `4rem` padding, out of step with the rest of the page). Also fixes a pre-existing desktop (`≥1024px`) bug where `.page-section`'s shorthand `padding` declaration was silently clobbering `.section-compact`'s reduced vertical padding — it now only sets left/right at that breakpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)