### PR TITLE
fix: reserve min-height for location card addresses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,14 @@ apex-site-basingstoke.repair/
 3. **Kings Furlong Repair Café**
    - Status: Coming Later in 2025
 
+**When adding a new location**: check its address (in `src/content/locations/`)
+against the number of lines rendered by `.location-address` in
+`src/components/Locations.astro`. The card grid uses a shared min-height
+(defined in `src/styles/global.css`, currently sized for a 3-line address —
+venue, street, postcode) so map iframes stay aligned across cards on
+multi-column layouts. An address needing a 4th line requires bumping that
+min-height too.
+
 ### Contact Information
 - Email: info@chinehamrepair.org.uk
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ npm start
    - `hatch-warren-team.jpg`
    - Recommended size: 800x600px
 
+> **Note (Astro V2):** the locations grid itself now lives in
+> `src/components/Locations.astro` / `src/styles/global.css` rather than
+> `public/index.html`. Its `.location-address` block has a min-height sized
+> for a 3-line address (venue, street, postcode) so map iframes stay aligned
+> when cards sit side-by-side — check that value if a new location's address
+> needs more lines.
+
 4. **Supporter Logos** (`public/assets/images/supporters/`)
    - Individual logo files for each supporter
    - Transparent PNG recommended

--- a/src/components/Locations.astro
+++ b/src/components/Locations.astro
@@ -58,8 +58,13 @@ function formatTime(t: string) {
                 </div>
               )}
 
+              {/* .location-address has a min-height (see global.css) sized for
+                 a 3-line address (venue + street + postcode) so the map below
+                 stays aligned across cards on multi-column layouts. If a new
+                 location's address needs a 4th line, that min-height must
+                 grow too. */}
               {address && (
-                <p>
+                <p class="location-address">
                   <strong>{address.venue}</strong>
                   {address.street && <><br />{address.street}</>}
                   <br />{address.postcode}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -535,6 +535,14 @@ img {
   font-size: 0.9rem;
 }
 
+/* Reserves height for a 3-line address (venue + street + postcode) — the
+   longest an address currently gets (see Chineham). Only applied once
+   .location-grid goes multi-column (>=640px, see media query below), so
+   shorter addresses (e.g. Hatch Warren, which has no street line) don't
+   leave the map iframe below misaligned between cards on the same row.
+   MIN_LOCATION_ADDRESS_HEIGHT_REM: bump this (and the comment) if a future
+   location's address needs more than 3 lines. */
+
 .map-container {
   width: 100%;
   height: 300px;
@@ -845,6 +853,14 @@ button:focus-visible {
 
   .location-grid {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  /* 3 lines x 1.6 line-height, sized for this breakpoint's largest body
+     font-size (18px at >=1024px) so the address block covers the tallest
+     rendered address rather than the 16px/root rem basis. See the
+     MIN_LOCATION_ADDRESS_HEIGHT_REM comment above .location-meta span. */
+  .location-address {
+    min-height: 5.4rem;
   }
 }
 


### PR DESCRIPTION
Resolves #108. Location addresses vary in length (Chineham has a street line, Hatch Warren doesn't), so on multi-column layouts (>=640px) the shorter address left its card's map iframe sitting higher than its neighbour's. Add a .location-address min-height, sized in rem for the longest (3-line) address at the largest body font-size the multi-column breakpoint reaches, so map iframes line up across cards on the same row.

Documents the constraint at the point of use (global.css comment, Locations.astro comment) and in CLAUDE.md / README.md so it's reviewed when a new location's address needs more lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)